### PR TITLE
Move sc-web installation from ostis-web-platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+## About
+Current repository contains web interface for ostis platform ([here](https://github.com/ostis-ai) you can find all ostis modules).
+
+## Installation
+### Installing requirements:
+* python3
+* pip
+* nodejs
+* npm
+* grunt-cli
+* python modules: tornado, sqlalchemy, python-rocksdb, progress, numpy, configparser
+
+### Building
+To install current module on debian based distros you may use internal scripts. Run
+
+```shell
+    cd scripts
+    ./install.sh
+```
+
+### Running
+To run ostis web interface you should build knowledge base and run sctp server. You can do it by running `./build_kb.sh` and `./run_sctp.sh` in installed [sc-machine](https://github.com/ostis-ai/sc-machine) module.

--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ To install current module on debian based distros you may use internal scripts. 
 ```
 
 ### Running
-To run ostis web interface you should build knowledge base and run sctp server. You can do it by running `./build_kb.sh` and `./run_sctp.sh` in installed [sc-machine](https://github.com/ostis-ai/sc-machine) module.
+To run ostis web interface you should build knowledge base and run sctp server. You can do it by running `./build_kb.sh` and `./run_sctp.sh` in [ostis-web-platform](https://github.com/ostis-ai/ostis-web-platform) module.

--- a/README.txt
+++ b/README.txt
@@ -1,1 +1,0 @@
-cloned from commit 68f09db907b0b4e4cd7e4d7dd084e37651832047 10 Feb 2016

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,6 @@
+./install_deps.sh
+npm install
+grunt build
+
+echo "Copy server.conf\n"
+mv ../server.conf ../server

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -1,0 +1,5 @@
+sudo apt install -y python python3-pip nodejs npm
+
+pip3 install tornado sqlalchemy python-rocksdb progress numpy configparser
+
+npm install grunt-cli

--- a/server.conf
+++ b/server.conf
@@ -1,0 +1,3 @@
+
+static_path = "../client/static"
+templates_path = "../client/templates"


### PR DESCRIPTION
That changes allow you to install [sc-web](https://github.com/ostis-ai/sc-web) separately from [ostis-web-platform](https://github.com/ostis-ai/ostis-web-platform). I also add default config file (_server.conf_) to repos root and script for installing general dependencies of sc-web.