### PR TITLE
Parse project configuration file to get kb.bin path

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,6 +1,3 @@
 ./install_deps.sh
 npm install
 grunt build
-
-echo "Copy server.conf\n"
-mv ../server.conf ../server

--- a/server.conf
+++ b/server.conf
@@ -1,3 +1,0 @@
-
-static_path = "../client/static"
-templates_path = "../client/templates"


### PR DESCRIPTION
This change will allow user to install sc-web in any location and launch it with a config used by sc-machine and other OSTIS tooling to determine path to KB dynamically. This solution works with both absolute and relative paths, relative paths are resolved starting at the config location. This change by itself doesn't break anything, because there's a fallback to previous default in case config file wasn't provided. New typical way to launch `sc-web` would be:
```sh
python3 app.py --cfg=<path/to/config.ini>
```
This PR is required by the changes made to ostis-web-platform, but does not depend on any other PR by itself.