### PR TITLE
Fix grunt existing error

### DIFF
--- a/scripts/install_deps_ubuntu.sh
+++ b/scripts/install_deps_ubuntu.sh
@@ -1,3 +1,4 @@
 sudo apt install --no-install-recommends -y python3 python3-pip nodejs npm
 
-npm install -g grunt-cli
+sudo apt -y remove grunt
+sudo npm install -g grunt-cli


### PR DESCRIPTION
Fix next error in CIs:
```
npm ERR! code EEXIST
npm ERR! path /usr/local/bin/grunt
npm ERR! EEXIST: file already exists
npm ERR! File exists: /usr/local/bin/grunt
npm ERR! Remove the existing file and try again, or run npm
npm ERR! with --force to overwrite files recklessly.
```