### PR TITLE
fix: add binary file types to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,10 @@
 * text eol=lf
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.eot binary
+*.ttf binary
+*.woff binary
+*.otf binary
+*.pdf binary


### PR DESCRIPTION
This will prevent line ending normalization for files which do not need this operation, the `git status` won't be tripped right after cloning this repo too.