### PR TITLE
fix: install nodejs from official repo

### DIFF
--- a/scripts/install_deps_ubuntu.sh
+++ b/scripts/install_deps_ubuntu.sh
@@ -1,2 +1,5 @@
 #!/usr/bin/env bash
+curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -
+sudo chmod a+r /usr/share/keyrings/nodesource.gpg
+sudo apt update
 sudo apt install --no-install-recommends -y python3 python3-pip nodejs


### PR DESCRIPTION
Ubuntu's repositories contain outdated version of nodejs and lead to an inconsistent state of the system if `npm` package is installed (`npm` provided within `nodejs` package in official repos, but it is a separate package in Ubuntu's repositories). This fix adds official nodejs repositories to the system and uses it instead: problems with `npm` upon installation should be resolved by this PR.