### PR TITLE
Change apt to apt-get for use in scripts

### DIFF
--- a/scripts/install_deps_ubuntu.sh
+++ b/scripts/install_deps_ubuntu.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-sudo apt install curl
+sudo apt-get install curl
 curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -
 sudo chmod a+r /usr/share/keyrings/nodesource.gpg
-sudo apt update
-sudo apt install --no-install-recommends -y python3 python3-pip nodejs
-sudo apt autoremove
+sudo apt-get update
+sudo apt-get install --no-install-recommends -y python3 python3-pip nodejs
+sudo apt-get autoremove


### PR DESCRIPTION
Change apt to apt-get in script `install_deps_ubuntu.sh` because [apt has no stable CLI interface](https://unix.stackexchange.com/questions/590699/should-i-use-apt-or-apt-get-in-shell-scripting).