### PR TITLE
Fix/identifiers translation

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Build docs in SCn format
 
 ### Fixed
+- Main and system identifier translation with current language in scg-editor
 - Check edges on addArcEventRequest and removeArcEventRequest ([120](https://github.com/ostis-ai/sc-web/issues/120), [121](https://github.com/ostis-ai/sc-web/issues/121))
 - Create links with unspecified constancy in scg-editor
 - SC.g-contours and its sc.g-elements create, edit, extend, select, move, click and delete


### PR DESCRIPTION
The logic is the same as in building gwf files
To test:
- Open scg-editor
- Create some node with identifier that fits system identifier rules (_**concept_my_class**_)
- Create some node that doesn't fit system identifier rules (_**my node**_)
- Synchronize
- Find your nodes and see that 1. There is no languages in identifiers and 2. There is system identifier for _**concept_my_class**_ and main  for _**my node**_
![image](https://github.com/ostis-ai/sc-web/assets/36566977/be244c7d-c77b-49da-abee-fc
![image](https://github.com/ostis-ai/sc-web/assets/36566977/ea440ddc-ad68-4a08-96c4-f198912a1a11)
5cec08b981)
