### PR TITLE
fix: update node installation script

### DIFF
--- a/scripts/install_deps_ubuntu.sh
+++ b/scripts/install_deps_ubuntu.sh
@@ -25,9 +25,13 @@ At the end run the following commands:
   exit 1
 fi
 
-sudo apt-get install curl
-curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -
-sudo chmod a+r /usr/share/keyrings/nodesource.gpg
+sudo apt-get install -y ca-certificates curl gnupg
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+
+NODE_MAJOR=16
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+
 sudo apt-get update
 sudo apt-get install --no-install-recommends -y "${packages[@]}"
 sudo apt-get autoremove


### PR DESCRIPTION
nodesource scripts are officially outdated, new scripts are made according to [Node.js documentation](https://github.com/nodesource/distributions)
![image](https://github.com/ostis-ai/sc-web/assets/43214067/45690388-02cc-452e-88eb-51234d5a290e)
