### PR TITLE
fix: long distance scg flip

### DIFF
--- a/components/scg/src/scg.js
+++ b/components/scg/src/scg.js
@@ -850,7 +850,7 @@ SCg.Editor.prototype = {
             const heightRatio = containerHeight / scgHeight;
             const widthRatio = containerWidth / scgWidth;
             let scale = currentScale * Math.min(heightRatio, widthRatio) - scaleDelta;
-            scale < 0 ? scale = 0.01 : scale;
+            if (scale < 0) scale = 0.01;
             const translateX = self.scene.render.d3_container[0][0].getBoundingClientRect().width * scale;
             const translateY = self.scene.render.d3_container[0][0].getBoundingClientRect().height * scale;
             

--- a/components/scg/src/scg.js
+++ b/components/scg/src/scg.js
@@ -849,7 +849,8 @@ SCg.Editor.prototype = {
             const currentScale = self.scene.render.scale;
             const heightRatio = containerHeight / scgHeight;
             const widthRatio = containerWidth / scgWidth;
-            const scale = currentScale * Math.min(heightRatio, widthRatio) - scaleDelta;
+            let scale = currentScale * Math.min(heightRatio, widthRatio) - scaleDelta;
+            scale < 0 ? scale = 0.01 : scale;
             const translateX = self.scene.render.d3_container[0][0].getBoundingClientRect().width * scale;
             const translateY = self.scene.render.d3_container[0][0].getBoundingClientRect().height * scale;
             


### PR DESCRIPTION
Scg flips if you move the node far and click auto-size button