### PR TITLE
feature: Add CORS headers to the server

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Add CLI argument to add hosts to CORS Allowed Origin header  
 - Duplicate target sc.g-elements on sc.g-scene for reflexive and multiple connectors
 - Change sc.g-links types
 - Change sc.g-links identifiers

--- a/server/app.py
+++ b/server/app.py
@@ -49,6 +49,7 @@ def parse_options():
                            help="time period between reconnects to the server in seconds",
                            type=float)
     tornado.options.define("public_url", default="ws://localhost:8090/ws_json", help="public server url", type=str)
+    tornado.options.define("allowed_origins", default="", help="Sets 'access-control-allow-origin' header", type=str)
     tornado.options.define("auth_redirect_port", default=80, help="host port", type=int)
 
     tornado.options.define("google_client_id", default="", help="client id for google auth", type=str)

--- a/server/handlers/base.py
+++ b/server/handlers/base.py
@@ -25,11 +25,10 @@ class User:
 class BaseHandler(web.RequestHandler):
     # CORS headers
     def set_default_headers(self):
-        self.set_header("access-control-allow-origin", options.options.allowed_origins)
-        self.set_header("Access-Control-Allow-Headers", "x-requested-with")
+        self.set_header("Access-Control-Allow-Origin", options.options.allowed_origins)
+        self.set_header('Access-Control-Allow-Credentials', "true")
         self.set_header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
-        self.set_header("Access-Control-Allow-Headers", "access-control-allow-origin,authorization,content-type")
-
+        self.set_header("Access-Control-Allow-Headers", "access-control-allow-origin,authorization,content-type,set-cookie")
     # response to the CORS preflight request
     def options(self):
         # no body

--- a/server/handlers/base.py
+++ b/server/handlers/base.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from typing import Optional, Awaitable
 
-from tornado import web
+from tornado import web, options
 import db
 import decorators
 
@@ -23,6 +23,18 @@ class User:
 
 
 class BaseHandler(web.RequestHandler):
+    # CORS headers
+    def set_default_headers(self):
+        self.set_header("access-control-allow-origin", options.options.allowed_origins)
+        self.set_header("Access-Control-Allow-Headers", "x-requested-with")
+        self.set_header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+        self.set_header("Access-Control-Allow-Headers", "access-control-allow-origin,authorization,content-type")
+
+    # response to the CORS preflight request
+    def options(self):
+        # no body
+        self.set_status(204)
+        self.finish()
     
     def data_received(self, chunk: bytes) -> Optional[Awaitable[None]]:
         raise NotImplementedError()
@@ -40,8 +52,7 @@ class BaseHandler(web.RequestHandler):
         if u:           
             return User(u, database)
         
-        return None             
-    
+        return None
+
     def get_user_id(self, email):
         pass
-    


### PR DESCRIPTION
This PR adds ability to use sc-web's API from web apps other than sc-web itself. Add `--allowed_origins=<protocol>://<host>:<port>` argument when launching `python3 app.py` to test it out.